### PR TITLE
feat: fix infer schema length and add glimpse()

### DIFF
--- a/male-seed-beetle/scripts/convert-with-core.py
+++ b/male-seed-beetle/scripts/convert-with-core.py
@@ -10,7 +10,7 @@ with open('../data-raw/data.tsv', 'r') as tsv:
             content = re.sub("\t", ",", line) 
             csv.write(content)
 
-df = pl.read_csv('../data-raw/data-ready.csv')
+df = pl.read_csv('../data-raw/data-ready.csv', infer_schema_length=100_000) 
 
 block_mapping = {1:"Block 1", 2:"Block 2", 3:"Block 3"}
 
@@ -22,3 +22,5 @@ df = df.rename({col: col.lower() for col in df.columns}).with_columns(
     )  
 
 df.write_csv('../data-raw/data-ready.csv')
+
+df.glimpse()


### PR DESCRIPTION
## Description

This PR adds the option to specify how many rows of data should be analysed in order to dertermine the data type. I swear I tried exactly this last week and it didn't work, but now it does.

Also adds the glimpse() function as discussed with LJ.

Don't forget to run the download data script if the file isn't already in the system.

Closes #25 

<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [ ] Ran spell-check
- [ ] Formatted Markdown
