### PR TITLE
chore: :technologist: create a `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Two members of the team will be notified about PRs
+
+* @K-Beicher @lwjohnst86


### PR DESCRIPTION
## Description

This PR adds the CODEOWNERS file to the repo setting LJ and KB as owners.

Closes #19 

<!-- Please delete as appropriate: -->
This PR needs a quick review.


